### PR TITLE
Fixed README logo image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/Extraweich/homopy/blob/main/docs/source/images/Homopy_Yellow.svg?raw=true", width="400">
+  <img src="docs/source/images/Homopy_Yellow.svg?raw=true", width="50%">
 </p>
 
 ***

--- a/docs/source/images/Homopy_Yellow.svg
+++ b/docs/source/images/Homopy_Yellow.svg
@@ -1,1 +1,194 @@
-<svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 538.14 429.73"><defs><style>.cls-1{fill:none;}.cls-2{clip-path:url(#clip-path);}.cls-3,.cls-9{fill:#ffd966;}.cls-4{fill:#cdae52;}.cls-10,.cls-11,.cls-4,.cls-5,.cls-6,.cls-7{fill-rule:evenodd;}.cls-5,.cls-8{fill:#ffe084;}.cls-6{fill:#767171;}.cls-7{fill:#adaaaa;}.cls-9{font-size:80.04px;font-family:Tahoma-Bold, Tahoma;font-weight:700;}.cls-10{fill:#9dc3e6;}.cls-10,.cls-11{opacity:0.64;}.cls-11{fill:#c4dbf0;}</style><clipPath id="clip-path" transform="translate(-274.2 -47.39)"><rect class="cls-1" width="960" height="540"/></clipPath></defs><title>Homopy_Yellow</title><g class="cls-2"><rect class="cls-3" y="197.11" width="139.02" height="138.06"/><polygon class="cls-4" points="139.02 197.11 185.04 151.09 185.04 289.15 139.02 335.17 139.02 197.11"/><polygon class="cls-5" points="0 197.11 46.02 151.09 185.04 151.09 139.02 197.11 0 197.11"/><g class="cls-2"><path class="cls-6" d="M310.18,99.49c.24,2.21,4.15,3.59,8.75,3.1s8.12-2.69,7.88-4.89l40.48,374.43c.24,2.21-3.29,4.4-7.88,4.89s-8.51-.89-8.75-3.1Z" transform="translate(-274.2 -47.39)"/><path class="cls-7" d="M310.18,99.49c-.24-2.21,3.29-4.4,7.88-4.89s8.51.89,8.75,3.1-3.29,4.4-7.88,4.89-8.51-.89-8.75-3.1" transform="translate(-274.2 -47.39)"/></g><rect class="cls-8" x="319.01" y="217.69" width="35.85" height="41.8" transform="translate(-299.22 -7.39) rotate(-6.55)"/><g class="cls-2"><path class="cls-6" d="M323.58,218.69l16.5-1.83c.31,2.75-3.14,5.39-7.7,5.9s-8.5-1.32-8.81-4.07" transform="translate(-274.2 -47.39)"/></g><text class="cls-9" transform="translate(203.07 259.21)">HomoPy</text><g class="cls-2"><path class="cls-6" d="M403.35,51c-.1,2.22,3.55,4.19,8.17,4.4S420,54,420.05,51.81L402.67,426.15c-.1,2.22-3.93,3.84-8.54,3.63s-8.27-2.18-8.17-4.4Z" transform="translate(-274.2 -47.39)"/><path class="cls-7" d="M403.35,51c.1-2.22,3.93-3.84,8.54-3.62s8.27,2.18,8.17,4.4-3.93,3.84-8.54,3.63-8.27-2.18-8.17-4.4" transform="translate(-274.2 -47.39)"/></g><rect class="cls-8" x="379.26" y="218.12" width="41.8" height="23.44" transform="translate(-119.59 573.17) rotate(-87.72)"/><g class="cls-2"><path class="cls-6" d="M396.22,208.38l16.59.72c-.12,2.77-3.93,4.85-8.51,4.65s-8.2-2.6-8.08-5.37" transform="translate(-274.2 -47.39)"/></g><g class="cls-2"><path class="cls-10" d="M405.66,120.53c-.92,3.42,5.84,8.22,15.11,10.71s17.52,1.74,18.44-1.68L362.51,414.4c-.92,3.42-9.18,4.17-18.44,1.68s-16-7.29-15.11-10.71Z" transform="translate(-274.2 -47.39)"/><path class="cls-11" d="M405.66,120.53c.92-3.42,9.18-4.17,18.44-1.68s16,7.29,15.11,10.71-9.18,4.17-18.44,1.68-16-7.29-15.11-10.71" transform="translate(-274.2 -47.39)"/></g><rect class="cls-8" x="375.59" y="221.44" width="34.28" height="39.97" transform="translate(-213.77 513.56) rotate(-75.46)"/><g class="cls-2"><path class="cls-10" d="M412.47,228.86l-33.66-8.92c-1.29,4.85,5.21,10.78,14.5,13.24s17.87.53,19.16-4.32" transform="translate(-274.2 -47.39)"/></g><rect class="cls-3" x="0.42" y="197.13" width="138.6" height="137.88"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="Ebene_1"
+   data-name="Ebene 1"
+   viewBox="0 0 574.31023 429.72875"
+   version="1.1"
+   sodipodi:docname="Homopy_Yellow.svg"
+   width="574.31024"
+   height="429.72876"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview76"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="2.3898726"
+     inkscape:cx="269.05199"
+     inkscape:cy="215.28344"
+     inkscape:window-width="2498"
+     inkscape:window-height="1376"
+     inkscape:window-x="62"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Ebene_1" />
+  <defs
+     id="defs23">
+    <style
+       id="style18">.cls-1{fill:none;}.cls-2{clip-path:url(#clip-path);}.cls-3,.cls-9{fill:#ffd966;}.cls-4{fill:#cdae52;}.cls-10,.cls-11,.cls-4,.cls-5,.cls-6,.cls-7{fill-rule:evenodd;}.cls-5,.cls-8{fill:#ffe084;}.cls-6{fill:#767171;}.cls-7{fill:#adaaaa;}.cls-9{font-size:80.04px;font-family:Tahoma-Bold, Tahoma;font-weight:700;}.cls-10{fill:#9dc3e6;}.cls-10,.cls-11{opacity:0.64;}.cls-11{fill:#c4dbf0;}</style>
+    <clipPath
+       id="clip-path"
+       transform="translate(-274.2 -47.39)">
+      <rect
+         class="cls-1"
+         width="960"
+         height="540"
+         id="rect20"
+         x="0"
+         y="0" />
+    </clipPath>
+  </defs>
+  <title
+     id="title25">Homopy_Yellow</title>
+  <g
+     class="cls-2"
+     clip-path="url(#clip-path)"
+     id="g73">
+    <rect
+       class="cls-3"
+       y="197.11"
+       width="139.02"
+       height="138.06"
+       id="rect27"
+       x="0" />
+    <polygon
+       class="cls-4"
+       points="139.02,197.11 185.04,151.09 185.04,289.15 139.02,335.17 "
+       id="polygon29" />
+    <polygon
+       class="cls-5"
+       points="0,197.11 46.02,151.09 185.04,151.09 139.02,197.11 "
+       id="polygon31" />
+    <g
+       class="cls-2"
+       clip-path="url(#clip-path)"
+       id="g37">
+      <path
+         class="cls-6"
+         d="m 310.18,99.49 c 0.24,2.21 4.15,3.59 8.75,3.1 4.6,-0.49 8.12,-2.69 7.88,-4.89 l 40.48,374.43 c 0.24,2.21 -3.29,4.4 -7.88,4.89 -4.59,0.49 -8.51,-0.89 -8.75,-3.1 z"
+         transform="translate(-274.2,-47.39)"
+         id="path33" />
+      <path
+         class="cls-7"
+         d="m 310.18,99.49 c -0.24,-2.21 3.29,-4.4 7.88,-4.89 4.59,-0.49 8.51,0.89 8.75,3.1 0.24,2.21 -3.29,4.4 -7.88,4.89 -4.59,0.49 -8.51,-0.89 -8.75,-3.1"
+         transform="translate(-274.2,-47.39)"
+         id="path35" />
+    </g>
+    <rect
+       class="cls-8"
+       x="319.01001"
+       y="217.69"
+       width="35.849998"
+       height="41.799999"
+       transform="rotate(-6.55,-214.18322,2610.865)"
+       id="rect39" />
+    <g
+       class="cls-2"
+       clip-path="url(#clip-path)"
+       id="g43">
+      <path
+         class="cls-6"
+         d="m 323.58,218.69 16.5,-1.83 c 0.31,2.75 -3.14,5.39 -7.7,5.9 -4.56,0.51 -8.5,-1.32 -8.81,-4.07"
+         transform="translate(-274.2,-47.39)"
+         id="path41" />
+    </g>
+    <text
+       class="cls-9"
+       transform="translate(203.07,259.21)"
+       id="text45">HomoPy</text>
+    <g
+       class="cls-2"
+       clip-path="url(#clip-path)"
+       id="g51">
+      <path
+         class="cls-6"
+         d="m 403.35,51 c -0.1,2.22 3.55,4.19 8.17,4.4 4.62,0.21 8.48,-1.4 8.53,-3.59 l -17.38,374.34 c -0.1,2.22 -3.93,3.84 -8.54,3.63 -4.61,-0.21 -8.27,-2.18 -8.17,-4.4 z"
+         transform="translate(-274.2,-47.39)"
+         id="path47" />
+      <path
+         class="cls-7"
+         d="m 403.35,51 c 0.1,-2.22 3.93,-3.84 8.54,-3.62 4.61,0.22 8.27,2.18 8.17,4.4 -0.1,2.22 -3.93,3.84 -8.54,3.63 -4.61,-0.21 -8.27,-2.18 -8.17,-4.4"
+         transform="translate(-274.2,-47.39)"
+         id="path49" />
+    </g>
+    <rect
+       class="cls-8"
+       x="379.26001"
+       y="218.12"
+       width="41.799999"
+       height="23.440001"
+       transform="rotate(-87.72,238.4273,348.80808)"
+       id="rect53" />
+    <g
+       class="cls-2"
+       clip-path="url(#clip-path)"
+       id="g57">
+      <path
+         class="cls-6"
+         d="m 396.22,208.38 16.59,0.72 c -0.12,2.77 -3.93,4.85 -8.51,4.65 -4.58,-0.2 -8.2,-2.6 -8.08,-5.37"
+         transform="translate(-274.2,-47.39)"
+         id="path55" />
+    </g>
+    <g
+       class="cls-2"
+       clip-path="url(#clip-path)"
+       id="g63">
+      <path
+         class="cls-10"
+         d="m 405.66,120.53 c -0.92,3.42 5.84,8.22 15.11,10.71 9.27,2.49 17.52,1.74 18.44,-1.68 l -76.7,284.84 c -0.92,3.42 -9.18,4.17 -18.44,1.68 -9.26,-2.49 -16,-7.29 -15.11,-10.71 z"
+         transform="translate(-274.2,-47.39)"
+         id="path59" />
+      <path
+         class="cls-11"
+         d="m 405.66,120.53 c 0.92,-3.42 9.18,-4.17 18.44,-1.68 9.26,2.49 16,7.29 15.11,10.71 -0.89,3.42 -9.18,4.17 -18.44,1.68 -9.26,-2.49 -16,-7.29 -15.11,-10.71"
+         transform="translate(-274.2,-47.39)"
+         id="path61" />
+    </g>
+    <rect
+       class="cls-8"
+       x="375.59"
+       y="221.44"
+       width="34.279999"
+       height="39.970001"
+       transform="rotate(-75.46,224.99022,394.92348)"
+       id="rect65" />
+    <g
+       class="cls-2"
+       clip-path="url(#clip-path)"
+       id="g69">
+      <path
+         class="cls-10"
+         d="m 412.47,228.86 -33.66,-8.92 c -1.29,4.85 5.21,10.78 14.5,13.24 9.29,2.46 17.87,0.53 19.16,-4.32"
+         transform="translate(-274.2,-47.39)"
+         id="path67" />
+    </g>
+    <rect
+       class="cls-3"
+       x="0.41999999"
+       y="197.13"
+       width="138.60001"
+       height="137.88"
+       id="rect71" />
+  </g>
+  <metadata
+     id="metadata236">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Homopy_Yellow</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>


### PR DESCRIPTION
To address this issue, #23, which produces this cropped effect: 
![Screenshot from 2023-07-07 13-26-05](https://github.com/Extraweich/homopy/assets/8392709/478df0a8-c9fd-435a-afd6-9285b1bb8606)

I  edited the logo image in Inkscape and made the page fit the content. 
![Screenshot from 2023-07-07 13-27-33](https://github.com/Extraweich/homopy/assets/8392709/a75bffe3-76ea-491b-8dfa-41fa71c624fc)

In addition to this I edited the html in the README to have: 
```html
<p align="center">
  <img src="docs/source/images/Homopy_Yellow.svg?raw=true", width="50%">
</p>
```
I.e. I used `width="50%"` rather than `width=400`, since the former is more responsive to different screen sizes. However that may be personal. Furthermore I changed the image path to refer to the local image rather than the GitHub web link directly. But you may wish to revert that. 
